### PR TITLE
(GH-66) Update Cake.Issues to 0.8.0

### DIFF
--- a/src/Cake.Issues.PullRequests.AppVeyor.Tests/Cake.Issues.PullRequests.AppVeyor.Tests.csproj
+++ b/src/Cake.Issues.PullRequests.AppVeyor.Tests/Cake.Issues.PullRequests.AppVeyor.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Issues.Testing" Version="0.7.0" />
+    <PackageReference Include="Cake.Issues.Testing" Version="0.8.0-beta0001" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
     <PackageReference Include="Cake.Core" Version="0.33.0" />
     <PackageReference Include="Cake.Testing" Version="0.33.0" />

--- a/src/Cake.Issues.PullRequests.AppVeyor/AppVeyorBuildSettings.cs
+++ b/src/Cake.Issues.PullRequests.AppVeyor/AppVeyorBuildSettings.cs
@@ -6,7 +6,7 @@
     public class AppVeyorBuildSettings
     {
         private string messagePattern = "Project: {ProjectName}, File: {FilePath}, Line: {Line}";
-        private string detailsPattern = "{Rule}: {Message}";
+        private string detailsPattern = "{Rule}: {MessageText}";
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AppVeyorBuildSettings"/> class.
@@ -33,7 +33,7 @@
         /// <summary>
         /// Gets or sets the pattern of the message details to display.
         /// See <see cref="Cake.Issues.IIssueExtensions.ReplaceIssuePattern(string, IIssue)"/> for possible patterns.
-        /// The default value is: "{Rule}: {Message}".
+        /// The default value is: "{Rule}: {MessageText}".
         /// </summary>
         public string DetailsPattern
         {

--- a/src/Cake.Issues.PullRequests.AppVeyor/Cake.Issues.PullRequests.AppVeyor.csproj
+++ b/src/Cake.Issues.PullRequests.AppVeyor/Cake.Issues.PullRequests.AppVeyor.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -24,8 +24,8 @@
   <ItemGroup>
     <PackageReference Include="Cake.Common" Version="0.33.0" PrivateAssets="All" />
     <PackageReference Include="Cake.Core" Version="0.33.0" PrivateAssets="All" />
-    <PackageReference Include="Cake.Issues" Version="0.7.0" />
-    <PackageReference Include="Cake.Issues.PullRequests" Version="0.7.0" />
+    <PackageReference Include="Cake.Issues" Version="0.8.0-beta0001" />
+    <PackageReference Include="Cake.Issues.PullRequests" Version="0.8.0-beta0001" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.6" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" />
   </ItemGroup>


### PR DESCRIPTION
Updates Cake.Issues to 0.8.0. 

The `{Message}` pattern in `AppVeyorBuildSettings.MessagePattern` and  `AppVeyorBuildSettings.DetailsPattern` has been replaced with `{MessageText}`, `{MessageHtml}` and `{MessageMarkdown}`.

Fixes #66 