### PR TITLE
(GH-150) Multi-Target .NET Core 3.1, 5 & 6 instead of .NET Standard 2.0

### DIFF
--- a/nuspec/nuget/Cake.Issues.PullRequests.AppVeyor.nuspec
+++ b/nuspec/nuget/Cake.Issues.PullRequests.AppVeyor.nuspec
@@ -26,8 +26,14 @@ See the Project Site for an overview of the whole ecosystem of addins for workin
   </metadata>
   <files>
     <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />
-    <file src="netstandard2.0\Cake.Issues.PullRequests.AppVeyor.dll" target="lib\netstandard2.0" />
-    <file src="netstandard2.0\Cake.Issues.PullRequests.AppVeyor.pdb" target="lib\netstandard2.0" />
-    <file src="netstandard2.0\Cake.Issues.PullRequests.AppVeyor.xml" target="lib\netstandard2.0" />
+    <file src="netcoreapp3.1\Cake.Issues.PullRequests.AppVeyor.dll" target="lib\netcoreapp3.1" />
+    <file src="netcoreapp3.1\Cake.Issues.PullRequests.AppVeyor.pdb" target="lib\netcoreapp3.1" />
+    <file src="netcoreapp3.1\Cake.Issues.PullRequests.AppVeyor.xml" target="lib\netcoreapp3.1" />
+    <file src="net5.0\Cake.Issues.PullRequests.AppVeyor.dll" target="lib\net5.0" />
+    <file src="net5.0\Cake.Issues.PullRequests.AppVeyor.pdb" target="lib\net5.0" />
+    <file src="net5.0\Cake.Issues.PullRequests.AppVeyor.xml" target="lib\net5.0" />
+    <file src="net6.0\Cake.Issues.PullRequests.AppVeyor.dll" target="lib\net6.0" />
+    <file src="net6.0\Cake.Issues.PullRequests.AppVeyor.pdb" target="lib\net6.0" />
+    <file src="net6.0\Cake.Issues.PullRequests.AppVeyor.xml" target="lib\net6.0" />
   </files>
 </package>

--- a/recipe.cake
+++ b/recipe.cake
@@ -19,7 +19,11 @@ BuildParameters.PrintParameters(Context);
 
 ToolSettings.SetToolSettings(
     context: Context,
-    dupFinderExcludePattern: new string[] { BuildParameters.RootDirectoryPath + "/src/Cake.Issues.PullRequests.AppVeyor.Tests/*.cs" },
+    dupFinderExcludePattern: new string[]
+    {
+        BuildParameters.RootDirectoryPath + "/src/Cake.Issues.PullRequests.AppVeyor*/**/*.AssemblyInfo.cs",
+        BuildParameters.RootDirectoryPath + "/src/Cake.Issues.PullRequests.AppVeyor.Tests/**/*.cs"
+    },
     testCoverageFilter: "+[*]* -[xunit.*]* -[Cake.Core]* -[Cake.Testing]* -[*.Tests]* -[Cake.Issues]* -[Cake.Issues.Testing]* -[Cake.Issues.PullRequests]* -[Shouldly]* -[DiffEngine]* -[EmptyFiles]*",
     testCoverageExcludeByAttribute: "*.ExcludeFromCodeCoverage*",
     testCoverageExcludeByFile: "*/*Designer.cs;*/*.g.cs;*/*.g.i.cs");

--- a/src/Cake.Issues.PullRequests.AppVeyor.Tests/Cake.Issues.PullRequests.AppVeyor.Tests.csproj
+++ b/src/Cake.Issues.PullRequests.AppVeyor.Tests/Cake.Issues.PullRequests.AppVeyor.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <Product>Cake.Issues</Product>
     <Copyright>Copyright © Pascal Berger and contributors</Copyright>

--- a/src/Cake.Issues.PullRequests.AppVeyor/Cake.Issues.PullRequests.AppVeyor.csproj
+++ b/src/Cake.Issues.PullRequests.AppVeyor/Cake.Issues.PullRequests.AppVeyor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <Description>Addin for writing code analyzer or linter issues to AppVeyor</Description>
     <Authors>Pascal Berger</Authors>
     <Copyright>Copyright © Pascal Berger and contributors</Copyright>
@@ -12,14 +12,7 @@
     <DebugSymbols>true</DebugSymbols>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <CodeAnalysisRuleSet>..\Cake.Issues.PullRequests.AppVeyor.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
-    <DocumentationFile>bin\Debug\netstandard2.0\Cake.Issues.PullRequests.AppVeyor.xml</DocumentationFile>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.0|AnyCPU'">
-    <DocumentationFile>bin\Release\netstandard2.0\Cake.Issues.PullRequests.AppVeyor.xml</DocumentationFile>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Cake.Issues.PullRequests.AppVeyor.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Multi-Target .NET Core 3.1, 5, & 6 to follow best-practices for Cake 2.0.

Fixes #150